### PR TITLE
I have fixed the JavaScript syntax error in `index.html`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4674,14 +4674,6 @@ async function loadState() {
     let records = null;
     let error = null;
     
-async function loadState() {
-    console.log('Starting loadState function...');
-    const urlParams = new URLSearchParams(window.location.search);
-    const portalId = urlParams.get('portal');
-    
-    let records = null;
-    let error = null;
-    
     // First try to load from localStorage for offline mode
     try {
         const localData = localStorage.getItem('schedule-nsg-state');


### PR DESCRIPTION
I removed a duplicated and incomplete `async function loadState()` definition from the main inline script. This was causing an `Uncaught SyntaxError: Unexpected end of input`, which prevented your application's JavaScript from executing.

By deleting the erroneous code block, I have resolved the syntax error, leaving the single correct function definition.