### PR TITLE
fix: Correct the serve script to use Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
-    "serve": "python3 -m http.server 8000"
+    "serve": "node server.js"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
The serve script was previously using a Python HTTP server, which was not the intended server for this application. This change updates the script to use `node server.js` to correctly start the Express server.